### PR TITLE
disable "anomoly detection" fields for now

### DIFF
--- a/.ansible/templates/fluent.conf.j2
+++ b/.ansible/templates/fluent.conf.j2
@@ -27,8 +27,8 @@
     environment {{ env }}
     host.hostname {{ ansible_hostname }}
     host.name {{ inventory_hostname }}
-    service.name docker
-    event.dataset docker.${record["stream"]}
+    #service.name docker
+    #event.dataset docker.${record["stream"]}
   </record>
   remove_keys time, log, container_id, container_hostname, container_name
 </filter>


### PR DESCRIPTION
- I think this is messing with me because it's supposed to be a paid only feature. however they seem to give user's a "glimpse" of it when the event.dataset field is left blank. Thanks elastic for wasting about 5 hours of my life.